### PR TITLE
Rule formatting

### DIFF
--- a/guides/payment-methods/card/3ds.mdx
+++ b/guides/payment-methods/card/3ds.mdx
@@ -152,7 +152,7 @@ The following transaction types may be exempted from SCA if accepted by the issu
                 - More than €100 in cumulated transactions
                 These limits have no timeframe and transactions with any payment service provider (PSP) count towards the limits.
 
-                _**Note:** Amounts considered as low can vary depending on the bank, currency, and Mangopay’s internal rules to ensure a smooth and secure experience._
+                **Note:** Amounts considered as low can vary depending on the bank, currency, and Mangopay’s internal rules to ensure a smooth and secure experience.
             </td>
         </tr>
         <tr>

--- a/guides/payouts.mdx
+++ b/guides/payouts.mdx
@@ -222,7 +222,7 @@ If a payout containing a `PAYIN_REFUND` reference is returned, it follows the sa
 <Note>
 **Note – Refunds using payouts via the Dashboard**
 
-The Mangopay Dashboard allows you to initiate refunds using payouts for bank wire and virtual IBAN pay-ins. To do so, use the ___Refund___ button on the pay-in details screen.
+The Mangopay Dashboard allows you to initiate refunds using payouts for bank wire and virtual IBAN pay-ins. To do so, use the ***Refund*** button on the pay-in details screen.
 </Note>
 
 ## Payout returns  

--- a/guides/users/verification/requirements/kyb-local.mdx
+++ b/guides/users/verification/requirements/kyb-local.mdx
@@ -2107,7 +2107,7 @@ Local structures considered in this type:
 <tr>
 <th class="header">Registration&nbsp;proof</th>
 <td class="table-content">
-Company snapshot from <a href="https://find-and-update.company-information.service.gov.uk/">Companies House</a> (recommended, accessible via company page (URI) > tab _**More**_ > _**View company information snapshot**_ ), or else latest confirmation statement or annual return, not older than 3 months.
+Company snapshot from <a href="https://find-and-update.company-information.service.gov.uk/">Companies House</a> (recommended, accessible via company page (URI) > tab ***More*** > ***View company information snapshot*** ), or else latest confirmation statement or annual return, not older than 3 months.
 </td>
 </tr>
 <tr>

--- a/snippets/object-attributes/Country.mdx
+++ b/snippets/object-attributes/Country.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-**Allowed values:** Country code in the <a href="/api-reference/overview/data-formats">ISO 3166-1 alpha-2</a> format.
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/Country10.mdx
+++ b/snippets/object-attributes/Country10.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-**Allowed values:** Country code in the <a href="/api-reference/overview/data-formats">ISO 3166-1 alpha-2</a> format.
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/Country5.mdx
+++ b/snippets/object-attributes/Country5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/Country5.mdx
+++ b/snippets/object-attributes/Country5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/Country5.mdx
+++ b/snippets/object-attributes/Country5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/Country6.mdx
+++ b/snippets/object-attributes/Country6.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country in which the beneficial owner was born. 
 </ParamField>

--- a/snippets/object-attributes/Country6.mdx
+++ b/snippets/object-attributes/Country6.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country in which the beneficial owner was born. 
 </ParamField>

--- a/snippets/object-attributes/Country6.mdx
+++ b/snippets/object-attributes/Country6.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country in which the beneficial owner was born. 
 </ParamField>

--- a/snippets/object-attributes/Country7.mdx
+++ b/snippets/object-attributes/Country7.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-**Allowed values:** Country code in the <a href="/api-reference/overview/data-formats">ISO 3166-1 alpha-2</a> format.
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/Country9.mdx
+++ b/snippets/object-attributes/Country9.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string">     
-**Allowed values:** Country code in the <a href="/api-reference/overview/data-formats">ISO 3166-1 alpha-2</a> format.
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/object-attributes/CountryCode.mdx
+++ b/snippets/object-attributes/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the registration of the legal entity, against which the company number format is validated. 
 </ParamField>

--- a/snippets/object-attributes/CountryCode.mdx
+++ b/snippets/object-attributes/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the registration of the legal entity, against which the company number format is validated. 
 </ParamField>

--- a/snippets/object-attributes/CountryCode.mdx
+++ b/snippets/object-attributes/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the registration of the legal entity, against which the company number format is validated. 
 </ParamField>

--- a/snippets/object-attributes/CountryCode1.mdx
+++ b/snippets/object-attributes/CountryCode1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The code of the country.  
 </ParamField>

--- a/snippets/object-attributes/CountryCode1.mdx
+++ b/snippets/object-attributes/CountryCode1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The code of the country.  
 </ParamField>

--- a/snippets/object-attributes/CountryCode1.mdx
+++ b/snippets/object-attributes/CountryCode1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The code of the country.  
 </ParamField>

--- a/snippets/object-attributes/FirstName3.mdx
+++ b/snippets/object-attributes/FirstName3.mdx
@@ -1,5 +1,5 @@
 <ParamField body="FirstName" type="string">  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The first name of the individual.
 </ParamField>

--- a/snippets/object-attributes/LastName3.mdx
+++ b/snippets/object-attributes/LastName3.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LastName" type="string">  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The last name of the user.  
 </ParamField>

--- a/snippets/object-attributes/ReturnURL3.mdx
+++ b/snippets/object-attributes/ReturnURL3.mdx
@@ -4,5 +4,5 @@ import MaxLength255Characters from '/snippets/rules/max-length-255-characters.md
 <MaxLength255Characters />     
 The URL to which the user is returned after the payment, whether the transaction is successful or not.
 
-_**Note:** This parameter is only returned if it is sent._
+**Note:** This parameter is only returned if it is sent.
 </ParamField>

--- a/snippets/p-body/Country5.mdx
+++ b/snippets/p-body/Country5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country5.mdx
+++ b/snippets/p-body/Country5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country5.mdx
+++ b/snippets/p-body/Country5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country6.mdx
+++ b/snippets/p-body/Country6.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country6.mdx
+++ b/snippets/p-body/Country6.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country6.mdx
+++ b/snippets/p-body/Country6.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country7.mdx
+++ b/snippets/p-body/Country7.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country7.mdx
+++ b/snippets/p-body/Country7.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country7.mdx
+++ b/snippets/p-body/Country7.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country8.mdx
+++ b/snippets/p-body/Country8.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country in which the beneficial owner was born. 
 </ParamField>

--- a/snippets/p-body/Country8.mdx
+++ b/snippets/p-body/Country8.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>     
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country in which the beneficial owner was born. 
 </ParamField>

--- a/snippets/p-body/Country8.mdx
+++ b/snippets/p-body/Country8.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country in which the beneficial owner was born. 
 </ParamField>

--- a/snippets/p-body/Country9.mdx
+++ b/snippets/p-body/Country9.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country9.mdx
+++ b/snippets/p-body/Country9.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/Country9.mdx
+++ b/snippets/p-body/Country9.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Country" type="string" required>
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ParamField>

--- a/snippets/p-body/CountryCode.mdx
+++ b/snippets/p-body/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string" required>     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the registration of the legal entity, against which the company number format is validated.
 </ParamField>

--- a/snippets/p-body/CountryCode.mdx
+++ b/snippets/p-body/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string" required>     
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the registration of the legal entity, against which the company number format is validated.
 </ParamField>

--- a/snippets/p-body/CountryCode.mdx
+++ b/snippets/p-body/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryCode" type="string" required>     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the registration of the legal entity, against which the company number format is validated.
 </ParamField>

--- a/snippets/p-body/CountryOfResidence.mdx
+++ b/snippets/p-body/CountryOfResidence.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryOfResidence" type="string" >     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/CountryOfResidence.mdx
+++ b/snippets/p-body/CountryOfResidence.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryOfResidence" type="string" >     
-**Allowed values:** Two-letter country code  (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/CountryOfResidence.mdx
+++ b/snippets/p-body/CountryOfResidence.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryOfResidence" type="string" >     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/CountryOfResidence1.mdx
+++ b/snippets/p-body/CountryOfResidence1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryOfResidence" type="string" required>     
-***Format:** Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).*
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of residence of the individual.
 </ParamField>

--- a/snippets/p-body/CountryOfResidence1.mdx
+++ b/snippets/p-body/CountryOfResidence1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryOfResidence" type="string" required>     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of residence of the individual.
 </ParamField>

--- a/snippets/p-body/CountryOfResidence1.mdx
+++ b/snippets/p-body/CountryOfResidence1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="CountryOfResidence" type="string" required>     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of residence of the individual.
 </ParamField>

--- a/snippets/p-body/FirstName1.mdx
+++ b/snippets/p-body/FirstName1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="FirstName" type="string" required>  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The first name of the individual.  
 </ParamField>

--- a/snippets/p-body/FirstName5.mdx
+++ b/snippets/p-body/FirstName5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="FirstName" type="string">  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The first name of the individual.  
 </ParamField>

--- a/snippets/p-body/LastName1.mdx
+++ b/snippets/p-body/LastName1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LastName" type="string" required>  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The last name of the individual.  
 </ParamField>

--- a/snippets/p-body/LastName5.mdx
+++ b/snippets/p-body/LastName5.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LastName" type="string">  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The last name of the individual.  
 </ParamField>

--- a/snippets/p-body/LegalRepresentativeCountryOfResidence.mdx
+++ b/snippets/p-body/LegalRepresentativeCountryOfResidence.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LegalRepresentativeCountryOfResidence" type="string" >     
-**Allowed values:** Two-letter country code  (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.  
 

--- a/snippets/p-body/LegalRepresentativeCountryOfResidence.mdx
+++ b/snippets/p-body/LegalRepresentativeCountryOfResidence.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LegalRepresentativeCountryOfResidence" type="string" >     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.  
 

--- a/snippets/p-body/LegalRepresentativeCountryOfResidence.mdx
+++ b/snippets/p-body/LegalRepresentativeCountryOfResidence.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LegalRepresentativeCountryOfResidence" type="string" >     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.  
 

--- a/snippets/p-body/LegalRepresentativeNationality.mdx
+++ b/snippets/p-body/LegalRepresentativeNationality.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LegalRepresentativeNationality" type="string" >     
-**Allowed values:** Two-letter country code  (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/LegalRepresentativeNationality.mdx
+++ b/snippets/p-body/LegalRepresentativeNationality.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LegalRepresentativeNationality" type="string" >     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/LegalRepresentativeNationality.mdx
+++ b/snippets/p-body/LegalRepresentativeNationality.mdx
@@ -1,5 +1,5 @@
 <ParamField body="LegalRepresentativeNationality" type="string" >     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/Nationality.mdx
+++ b/snippets/p-body/Nationality.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Nationality" type="string" >
-    **Allowed values:** Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+    Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
     Required if `UserCategory` is `OWNER`. Returned `null` if `UserCategory` is `PAYER`.
 

--- a/snippets/p-body/Nationality1.mdx
+++ b/snippets/p-body/Nationality1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Nationality" type="string" required>     
-    **Allowed values:** Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+    Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
     The nationality of the beneficial owner.  
 </ParamField>

--- a/snippets/p-body/Nationality2.mdx
+++ b/snippets/p-body/Nationality2.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Nationality" type="string">     
-    **Allowed values:** Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+    Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
     The nationality of the beneficial owner.  
 </ParamField>

--- a/snippets/p-body/Nationality3.mdx
+++ b/snippets/p-body/Nationality3.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Nationality" type="string" required>
-***Format:** Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).*
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The nationality of the individual.
 </ParamField>

--- a/snippets/p-body/Nationality3.mdx
+++ b/snippets/p-body/Nationality3.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Nationality" type="string" required>
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The nationality of the individual.
 </ParamField>

--- a/snippets/p-body/Nationality3.mdx
+++ b/snippets/p-body/Nationality3.mdx
@@ -1,5 +1,5 @@
 <ParamField body="Nationality" type="string" required>
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The nationality of the individual.
 </ParamField>

--- a/snippets/p-body/PhoneNumber.mdx
+++ b/snippets/p-body/PhoneNumber.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumber" type="string">
-***Format:** International telephone numbering plan E.164 (+ then country code then the number) or local format*
+Format: International telephone numbering plan E.164 (+ then country code then the number) or local format
 
 Required if `UserCategory` is `OWNER`. 
 

--- a/snippets/p-body/PhoneNumber1.mdx
+++ b/snippets/p-body/PhoneNumber1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumber" type="string">
-***Format:** International telephone numbering plan E.164 (+ then country code then the number) or local format*
+Format: International telephone numbering plan E.164 (+ then country code then the number) or local format
 
 The individual's phone number. 
 

--- a/snippets/p-body/PhoneNumberCountry.mdx
+++ b/snippets/p-body/PhoneNumberCountry.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumberCountry" type="string">
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-body/PhoneNumberCountry.mdx
+++ b/snippets/p-body/PhoneNumberCountry.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumberCountry" type="string">
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-body/PhoneNumberCountry.mdx
+++ b/snippets/p-body/PhoneNumberCountry.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumberCountry" type="string">
-**Allowed values:** Two-letter country code (ISO 3166-1 alpha-2 format).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-body/PhoneNumberCountry1.mdx
+++ b/snippets/p-body/PhoneNumberCountry1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumberCountry" type="string">
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-body/PhoneNumberCountry1.mdx
+++ b/snippets/p-body/PhoneNumberCountry1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumberCountry" type="string">
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-body/PhoneNumberCountry1.mdx
+++ b/snippets/p-body/PhoneNumberCountry1.mdx
@@ -1,5 +1,5 @@
 <ParamField body="PhoneNumberCountry" type="string">
-***Format:** Two-letter country code (ISO 3166-1 alpha-2 format).*
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-body/ReturnURL5.mdx
+++ b/snippets/p-body/ReturnURL5.mdx
@@ -4,5 +4,5 @@ import MaxLength255Characters from '/snippets/rules/max-length-255-characters.md
 <MaxLength255Characters />     
 The URL to which the user is returned after the payment, whether the transaction is successful or not.   
 
-_**Note**: This parameter is only returned if it is sent._
+**Note**: This parameter is only returned if it is sent.
 </ParamField>

--- a/snippets/p-path/CountryCode.mdx
+++ b/snippets/p-path/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField path="CountryCode" type="string" required>     
-**Allowed values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The code of the country.  
 </ParamField>

--- a/snippets/p-path/CountryCode.mdx
+++ b/snippets/p-path/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField path="CountryCode" type="string" required>     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The code of the country.  
 </ParamField>

--- a/snippets/p-path/CountryCode.mdx
+++ b/snippets/p-path/CountryCode.mdx
@@ -1,5 +1,5 @@
 <ParamField path="CountryCode" type="string" required>     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The code of the country.  
 </ParamField>

--- a/snippets/p-response/Country10Response.mdx
+++ b/snippets/p-response/Country10Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country10Response.mdx
+++ b/snippets/p-response/Country10Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country10Response.mdx
+++ b/snippets/p-response/Country10Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country1Response.mdx
+++ b/snippets/p-response/Country1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country1Response.mdx
+++ b/snippets/p-response/Country1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country1Response.mdx
+++ b/snippets/p-response/Country1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country2Response.mdx
+++ b/snippets/p-response/Country2Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country in which the bank account is registered.  
 </ResponseField>

--- a/snippets/p-response/Country2Response.mdx
+++ b/snippets/p-response/Country2Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country in which the bank account is registered.  
 </ResponseField>

--- a/snippets/p-response/Country2Response.mdx
+++ b/snippets/p-response/Country2Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country in which the bank account is registered.  
 </ResponseField>

--- a/snippets/p-response/Country6Response.mdx
+++ b/snippets/p-response/Country6Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country6Response.mdx
+++ b/snippets/p-response/Country6Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country6Response.mdx
+++ b/snippets/p-response/Country6Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country7Response.mdx
+++ b/snippets/p-response/Country7Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country7Response.mdx
+++ b/snippets/p-response/Country7Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country7Response.mdx
+++ b/snippets/p-response/Country7Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country8Response.mdx
+++ b/snippets/p-response/Country8Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country8Response.mdx
+++ b/snippets/p-response/Country8Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country8Response.mdx
+++ b/snippets/p-response/Country8Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the address. 
 </ResponseField>

--- a/snippets/p-response/Country9Response.mdx
+++ b/snippets/p-response/Country9Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country in which the beneficial owner was born. 
 </ResponseField>

--- a/snippets/p-response/Country9Response.mdx
+++ b/snippets/p-response/Country9Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country in which the beneficial owner was born. 
 </ResponseField>

--- a/snippets/p-response/Country9Response.mdx
+++ b/snippets/p-response/Country9Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="Country" type="string">     
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country in which the beneficial owner was born. 
 </ResponseField>

--- a/snippets/p-response/CountryCode1Response.mdx
+++ b/snippets/p-response/CountryCode1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="CountryCode" type="string" >    
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The country of the registration of the legal entity, against which the company number format is validated. 
 </ResponseField>

--- a/snippets/p-response/CountryCode1Response.mdx
+++ b/snippets/p-response/CountryCode1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="CountryCode" type="string" >    
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The country of the registration of the legal entity, against which the company number format is validated. 
 </ResponseField>

--- a/snippets/p-response/CountryCode1Response.mdx
+++ b/snippets/p-response/CountryCode1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="CountryCode" type="string" >    
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The country of the registration of the legal entity, against which the company number format is validated. 
 </ResponseField>

--- a/snippets/p-response/CountryCodeResponse.mdx
+++ b/snippets/p-response/CountryCodeResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="CountryCode" type="string" >    
-**Returned values:** Two-letter country code (<a href="/api-reference/overview/data-formats" target="_blank">ISO 3166-1 alpha-2 format</a>).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 The code of the country.  
 </ResponseField>

--- a/snippets/p-response/CountryCodeResponse.mdx
+++ b/snippets/p-response/CountryCodeResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="CountryCode" type="string" >    
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 The code of the country.  
 </ResponseField>

--- a/snippets/p-response/CountryCodeResponse.mdx
+++ b/snippets/p-response/CountryCodeResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="CountryCode" type="string" >    
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 The code of the country.  
 </ResponseField>

--- a/snippets/p-response/DebitedBankAccountResponse.mdx
+++ b/snippets/p-response/DebitedBankAccountResponse.mdx
@@ -8,7 +8,7 @@ import AccountNumber5Response from '/snippets/p-response/AccountNumber5Response.
 <ResponseField name="DebitedBankAccount" type="object" >    
 Information about the debited bank account.
 
-_**Note:**_ This information may only be available for EU IBANs.
+**Note:** This information may only be available for EU IBANs.
 
 <Expandable title="properties">  
 <IBANResponse />

--- a/snippets/p-response/FirstName1Response.mdx
+++ b/snippets/p-response/FirstName1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="FirstName" type="string" >  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The first name of the individual.  
 </ResponseField>

--- a/snippets/p-response/LastName1Response.mdx
+++ b/snippets/p-response/LastName1Response.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="LastName" type="string" >  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The last name of the individual.  
 </ResponseField>

--- a/snippets/p-response/LegalRepresentativeFirstNameResponse.mdx
+++ b/snippets/p-response/LegalRepresentativeFirstNameResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="LegalRepresentativeFirstName" type="string" >  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The first name of the entity’s legal representative.  
 </ResponseField>

--- a/snippets/p-response/LegalRepresentativeLastNameResponse.mdx
+++ b/snippets/p-response/LegalRepresentativeLastNameResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="LegalRepresentativeLastName" type="string" >  
-_Min. length: 1; max. length: 100_
+Min. length: 1; max. length: 100
 
 The last name of the entity’s legal representative.  
 </ResponseField>

--- a/snippets/p-response/PhoneNumberCountryResponse.mdx
+++ b/snippets/p-response/PhoneNumberCountryResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="PhoneNumberCountry" type="string">
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-response/PhoneNumberCountryResponse.mdx
+++ b/snippets/p-response/PhoneNumberCountryResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="PhoneNumberCountry" type="string">
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-response/PhoneNumberCountryResponse.mdx
+++ b/snippets/p-response/PhoneNumberCountryResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="PhoneNumberCountry" type="string">
-**Allowed values:** Two-letter country code (ISO 3166-1 alpha-2 format).
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
 
 Required if the `PhoneNumber` is provided in local format.
 

--- a/snippets/p-response/PhoneNumberResponse.mdx
+++ b/snippets/p-response/PhoneNumberResponse.mdx
@@ -1,5 +1,5 @@
 <ResponseField name="PhoneNumber" type="string">
-***Format:** International telephone numbering plan E.164 (+ then country code then the number) or local format*
+Format: International telephone numbering plan E.164 (+ then country code then the number) or local format
 
 Required if `UserCategory` is `OWNER`.
 

--- a/snippets/p-response/ReturnURL4Response.mdx
+++ b/snippets/p-response/ReturnURL4Response.mdx
@@ -4,5 +4,5 @@ import MaxLength255Characters from '/snippets/rules/max-length-255-characters.md
 <MaxLength255Characters />    
 The URL to which the user is returned after the payment, whether the transaction is successful or not.   
 
-_**Note:** This parameter is only returned if it is sent._
+**Note:** This parameter is only returned if it is sent.
 </ResponseField>

--- a/snippets/rules/6-or-8-digits.mdx
+++ b/snippets/rules/6-or-8-digits.mdx
@@ -1,3 +1,1 @@
-  
-
-_6 or 8 digits_
+Format: 6 or 8 digits

--- a/snippets/rules/digits-only.mdx
+++ b/snippets/rules/digits-only.mdx
@@ -1,3 +1,1 @@
-  
-
-_Digits only_
+Format: Digits only

--- a/snippets/rules/emails-must-be--40-characters.mdx
+++ b/snippets/rules/emails-must-be--40-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Emails must be ≤ 40 characters_
+Format: Emails must be ≤ 40 characters

--- a/snippets/rules/format-a-valid-email-address.mdx
+++ b/snippets/rules/format-a-valid-email-address.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: A valid email address_
+Format: A valid email address

--- a/snippets/rules/format-base64-encoded-file.mdx
+++ b/snippets/rules/format-base64-encoded-file.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: Base64 encoded file_
+Format: Base64 encoded file

--- a/snippets/rules/format-iso-3166-1-alpha-2-two-letter-country-code.mdx
+++ b/snippets/rules/format-iso-3166-1-alpha-2-two-letter-country-code.mdx
@@ -1,1 +1,1 @@
-Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).

--- a/snippets/rules/format-iso-3166-1-alpha-2-two-letter-country-code.mdx
+++ b/snippets/rules/format-iso-3166-1-alpha-2-two-letter-country-code.mdx
@@ -1,1 +1,1 @@
-Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats)).
+Format: Two-letter country code ([ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats))

--- a/snippets/rules/format-iso-3166-1-alpha-2-two-letter-country-code.mdx
+++ b/snippets/rules/format-iso-3166-1-alpha-2-two-letter-country-code.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: ISO 3166-1 alpha-2 two-letter country code_
+Format: Two-letter country code [ISO 3166-1 alpha-2 format](/api-reference/overview/data-formats).

--- a/snippets/rules/format-iso-3166-1-alpha-3-three-letter-country-code-eg-fra.mdx
+++ b/snippets/rules/format-iso-3166-1-alpha-3-three-letter-country-code-eg-fra.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: ISO-3166-1 alpha-3 three-letter country code (e.g., “FRA”)_
+Format: ISO-3166-1 alpha-3 three-letter country code (e.g., “FRA”)

--- a/snippets/rules/format-iso-639-1-alpha-2-two-letter-language-code.mdx
+++ b/snippets/rules/format-iso-639-1-alpha-2-two-letter-language-code.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: ISO 639-1 alpha-2 two-letter language code_
+Format: Two-letter language code ([ISO 639-1 alpha-2](/api-reference/overview/data-formats))

--- a/snippets/rules/format-mm-eg-03.mdx
+++ b/snippets/rules/format-mm-eg-03.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: “MM” (e.g., “03”)_
+Format: “MM” (e.g., “03”)

--- a/snippets/rules/format-mmyy.mdx
+++ b/snippets/rules/format-mmyy.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: “MMYY”_
+Format: “MMYY”

--- a/snippets/rules/format-phone-number-without-plus.mdx
+++ b/snippets/rules/format-phone-number-without-plus.mdx
@@ -1,1 +1,1 @@
-_Format: Country code without plus symbol, followed by hash symbol (#), followed by the number; only numeric characters and hash symbol_
+Format: Country code without plus symbol, followed by hash symbol (#), followed by the number; only numeric characters and hash symbol

--- a/snippets/rules/format-phone-number.mdx
+++ b/snippets/rules/format-phone-number.mdx
@@ -1,1 +1,1 @@
-_Format: [+CC][XXXXXXXXX] where +CC is the international dialing code and Xs are the local number, for example: [+33][689854321]_
+Format: [+CC][XXXXXXXXX] where +CC is the international dialing code and Xs are the local number, for example: [+33][689854321]

--- a/snippets/rules/format-serialized-json-object.mdx
+++ b/snippets/rules/format-serialized-json-object.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: Serialized JSON object_
+Format: Serialized JSON object

--- a/snippets/rules/format-yyyy-eg-2019.mdx
+++ b/snippets/rules/format-yyyy-eg-2019.mdx
@@ -1,3 +1,1 @@
-  
-
-_Format: "YYYY" (e.g., "2019")_
+Format: "YYYY" (e.g., "2019")

--- a/snippets/rules/hex-color-code.mdx
+++ b/snippets/rules/hex-color-code.mdx
@@ -1,3 +1,1 @@
-  
-
-_Hex color code_
+Hex color code

--- a/snippets/rules/length-3-digits.mdx
+++ b/snippets/rules/length-3-digits.mdx
@@ -1,3 +1,1 @@
-  
-
-_Length: 3 digits_
+Length: 3 digits

--- a/snippets/rules/length-5-digits.mdx
+++ b/snippets/rules/length-5-digits.mdx
@@ -1,3 +1,1 @@
-  
-
-_Length: 5 digits_
+Length: 5 digits

--- a/snippets/rules/length-8-digits.mdx
+++ b/snippets/rules/length-8-digits.mdx
@@ -1,3 +1,1 @@
-  
-
-_Length: 8 digits_
+Length: 8 digits

--- a/snippets/rules/length-9-characters.mdx
+++ b/snippets/rules/length-9-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Length: 9 characters_
+Length: 9 characters

--- a/snippets/rules/length-up-to-34-characters.mdx
+++ b/snippets/rules/length-up-to-34-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Length: Up to 34 characters_
+Max length: 34 characters

--- a/snippets/rules/length-up-to-34-characters.mdx
+++ b/snippets/rules/length-up-to-34-characters.mdx
@@ -1,1 +1,1 @@
-Max length: 34 characters
+Max. length: 34 characters

--- a/snippets/rules/max-7-decimal-places.mdx
+++ b/snippets/rules/max-7-decimal-places.mdx
@@ -1,1 +1,1 @@
-_Max. 7 decimal places_
+Max. 7 decimal places

--- a/snippets/rules/max-length-10-characters-only-alphanumeric-and-spaces.mdx
+++ b/snippets/rules/max-length-10-characters-only-alphanumeric-and-spaces.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 10 characters; only alphanumeric and spaces_
+Max. length: 10 characters; only alphanumeric and spaces

--- a/snippets/rules/max-length-100-characters.mdx
+++ b/snippets/rules/max-length-100-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 100 characters_
+Max. length: 100 characters

--- a/snippets/rules/max-length-127-characters-truncated-after.mdx
+++ b/snippets/rules/max-length-127-characters-truncated-after.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 127 characters (truncated after)_
+Max. length: 127 characters (truncated after)

--- a/snippets/rules/max-length-15-characters-international-telephone-numbering-plan-e164--followed-by-the-country-code-then-the-number.mdx
+++ b/snippets/rules/max-length-15-characters-international-telephone-numbering-plan-e164--followed-by-the-country-code-then-the-number.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 15 characters; international telephone numbering plan E.164 (+ followed by the country code, then the number)_
+Max. length: 15 characters; international telephone numbering plan E.164 (+ followed by the country code, then the number)

--- a/snippets/rules/max-length-2000-characters.mdx
+++ b/snippets/rules/max-length-2000-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 2,000 characters_
+Max. length: 2,000 characters

--- a/snippets/rules/max-length-220-characters.mdx
+++ b/snippets/rules/max-length-220-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 220 characters_
+Max. length: 220 characters

--- a/snippets/rules/max-length-255-characters-12-recommended.mdx
+++ b/snippets/rules/max-length-255-characters-12-recommended.mdx
@@ -1,1 +1,1 @@
-_Max. length: 255 characters (< 12 recommended)_
+Max. length: 255 characters (< 12 recommended)

--- a/snippets/rules/max-length-255-characters.mdx
+++ b/snippets/rules/max-length-255-characters.mdx
@@ -1,1 +1,1 @@
-_Max. length: 255 characters_
+Max. length: 255 characters

--- a/snippets/rules/max-length-45-characters-card-network-255-api.mdx
+++ b/snippets/rules/max-length-45-characters-card-network-255-api.mdx
@@ -1,2 +1,2 @@
 
-_Max. length: 45 characters passed to card network, 255 accepted by the API_
+Max. length: 45 characters passed to card network, 255 accepted by the API

--- a/snippets/rules/max-length-45-characters.mdx
+++ b/snippets/rules/max-length-45-characters.mdx
@@ -1,1 +1,1 @@
-_Max. length: 45 characters_
+Max. length: 45 characters

--- a/snippets/rules/max-length-50-characters-letters-and-digits-only.mdx
+++ b/snippets/rules/max-length-50-characters-letters-and-digits-only.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 50 characters (letters and digits only)_
+Max. length: 50 characters (letters and digits only)

--- a/snippets/rules/max-length-50-characters.mdx
+++ b/snippets/rules/max-length-50-characters.mdx
@@ -1,1 +1,1 @@
-_Max. length: 50 characters_
+Max. length: 50 characters

--- a/snippets/rules/max-length-6-characters.mdx
+++ b/snippets/rules/max-length-6-characters.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. length: 6 characters_
+Max. length: 6 characters

--- a/snippets/rules/max-length-SDD-100-BACS-10-characters-only-alphanumeric-and-spaces.mdx
+++ b/snippets/rules/max-length-SDD-100-BACS-10-characters-only-alphanumeric-and-spaces.mdx
@@ -1,1 +1,1 @@
-_Max. length: SEPA: 100 characters, BACS: truncated after 10 characters; only alphanumeric and spaces_
+Max. length: SEPA: 100 characters, BACS: truncated after 10 characters; only alphanumeric and spaces

--- a/snippets/rules/max-value-100.mdx
+++ b/snippets/rules/max-value-100.mdx
@@ -1,3 +1,1 @@
-  
-
-_Max. value: 100_
+Max. value: 100

--- a/snippets/rules/min-length-16-characters-max-length-36-characters-only-alphanumeric-and-dashes.mdx
+++ b/snippets/rules/min-length-16-characters-max-length-36-characters-only-alphanumeric-and-dashes.mdx
@@ -1,3 +1,1 @@
-  
-
-_Min. length: 16 characters; max. length: 36 characters; only alphanumeric and dashes_
+Min. length: 16 characters; max. length: 36 characters; only alphanumeric and dashes

--- a/snippets/rules/min-length-2-characters-max-length-45-characters-card-network-255-api.mdx
+++ b/snippets/rules/min-length-2-characters-max-length-45-characters-card-network-255-api.mdx
@@ -1,2 +1,2 @@
 
-_Min. length: 2 characters; max. length: 45 characters passed to card network, 255 accepted by the API_
+Min. length: 2 characters; max. length: 45 characters passed to card network, 255 accepted by the API

--- a/snippets/rules/object.mdx
+++ b/snippets/rules/object.mdx
@@ -1,3 +1,1 @@
-  
-
-_object_
+object

--- a/snippets/rules/start-value-1.mdx
+++ b/snippets/rules/start-value-1.mdx
@@ -1,3 +1,1 @@
-  
-
-_Start value: 1_
+Start value: 1

--- a/snippets/rules/string.mdx
+++ b/snippets/rules/string.mdx
@@ -1,3 +1,1 @@
-  
-
-_string_
+string

--- a/testing/payouts.mdx
+++ b/testing/payouts.mdx
@@ -15,7 +15,7 @@ To test payouts, you need to create a valid Bank Account and create a Payout to 
 - `AccountNumber` - 55779911
 - `SortCode` - 200000
 
-You can then use the _**<a href="https://hub.mangopay.com/" target="_blank">Sandbox operations</a>**_ view of the Dashboard to process the payout.  
+You can then use the ***<a href="https://hub.mangopay.com/" target="_blank">Sandbox operations</a>*** view of the Dashboard to process the payout.  
 
 ## Instant payout testing  
 


### PR DESCRIPTION
- Country code presented as a format rather than enum values (exceptions if only a few values available eg vIBAN)
- Remove italic and bold from formatting rules because (i) it's not consistent and (ii) it takes readability away from more important text (e.g. notes and cautions, allowed enum values (which retain bold))
- Harmonize remaining italic using asterisks only (no underscores) as per readme markdown convention