### PR TITLE
Extend max-width to use more of screen real estate

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -25,6 +25,18 @@ html {
   border: 1px solid lime !important;
 } */
 
+.max-w-8xl {
+  max-width: 104rem;
+}
+
+.max-w-6xl {
+  max-width: 78rem;
+}
+
+.h-\[calc\(100\%-10rem\)\] {
+  height: 100%;
+}
+
 /* Pills */
 .pill {
   display: inline-flex;

--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,9 @@
     "light": "#FCB069",
     "dark": "#222525"
   },
+  "styling": {
+    "eyebrows": "breadcrumbs"
+  },
   "favicon": "/logo/mgp-favicon.svg",
   "navigation": {
     "tabs": [

--- a/guides/currencies.mdx
+++ b/guides/currencies.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Currencies'  
-mode: 'wide'
+
 'og:description': "See coverage by currency across Mangopay features: key payment methods, wallets, payouts, and more."  
 description: "Summary of Mangopay features by currency"
 ---


### PR DESCRIPTION
All pages now as wide as wide mode, which simply displays or not on-this-page menu